### PR TITLE
Update package python-zarr from 2.18.2 to 2.18.3

### DIFF
--- a/pkgs/python-zarr/.SRCINFO
+++ b/pkgs/python-zarr/.SRCINFO
@@ -13,7 +13,7 @@ pkgbase = python-zarr
 	depends = python-asciitree
 	depends = python-numpy
 	depends = python-fasteners
-	depends = python-numcodecs>=0.6.4
+	depends = python-numcodecs
 	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-2.18.3.tar.gz
 	sha256sums = 2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce
 

--- a/pkgs/python-zarr/.SRCINFO
+++ b/pkgs/python-zarr/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-zarr
 	pkgdesc = An implementation of chunked, compressed, N-dimensional arrays for Python
-	pkgver = 2.18.2
+	pkgver = 2.18.3
 	pkgrel = 1
 	url = https://github.com/zarr-developers/zarr-python
 	arch = any
@@ -14,7 +14,7 @@ pkgbase = python-zarr
 	depends = python-numpy
 	depends = python-fasteners
 	depends = python-numcodecs>=0.6.4
-	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-2.18.2.tar.gz
-	sha256sums = 9bb393b8a0a38fb121dbb913b047d75db28de9890f6d644a217a73cf4ae74f47
+	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-2.18.3.tar.gz
+	sha256sums = 2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce
 
 pkgname = python-zarr

--- a/pkgs/python-zarr/PKGBUILD
+++ b/pkgs/python-zarr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 _name=zarr
 pkgname=python-zarr
-pkgver=2.18.2
+pkgver=2.18.3
 pkgrel=1
 pkgdesc='An implementation of chunked, compressed, N-dimensional arrays for Python'
 arch=(any)
@@ -10,7 +10,7 @@ license=(MIT)
 depends=(python-asciitree python-numpy python-fasteners 'python-numcodecs>=0.6.4')
 makedepends=(python-setuptools python-setuptools-scm python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('9bb393b8a0a38fb121dbb913b047d75db28de9890f6d644a217a73cf4ae74f47')
+sha256sums=('2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce')
 
 build() {
 	cd "$_name-$pkgver"

--- a/pkgs/python-zarr/PKGBUILD
+++ b/pkgs/python-zarr/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc='An implementation of chunked, compressed, N-dimensional arrays for Pyth
 arch=(any)
 url='https://github.com/zarr-developers/zarr-python'
 license=(MIT)
-depends=(python-asciitree python-numpy python-fasteners 'python-numcodecs>=0.6.4')
+depends=(python-asciitree python-numpy python-fasteners python-numcodecs)
 makedepends=(python-setuptools python-setuptools-scm python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
 sha256sums=('2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce')


### PR DESCRIPTION
PyPI update: zarr (2.18.2 -> 2.18.3)
~ {'numpy>=1.23 -> numpy>=1.24'}