### PR TITLE
Update package python-libmamba from 2.0.0 to 2024.09.30

### DIFF
--- a/pkgs/python-libmamba/.SRCINFO
+++ b/pkgs/python-libmamba/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = python-libmamba
 	pkgdesc = The fast cross-platform package manager
-	pkgver = 2.0.0
-	pkgrel = 2
+	pkgver = 2024.09.30
+	pkgrel = 1
 	url = https://github.com/mamba-org/mamba
 	arch = x86_64
 	license = BSD-3-Clause
@@ -25,10 +25,10 @@ pkgbase = python-libmamba
 	depends = reproc
 	depends = yaml-cpp>=0.8.0
 	depends = simdjson
-	provides = libmamba=2.0.0
-	provides = python-libmambapy=2.0.0
+	provides = libmamba=2024.09.30
+	provides = python-libmambapy=2024.09.30
 	conflicts = micromamba
-	source = mamba-2024.09.25-2.0.0.tar.gz::https://github.com/mamba-org/mamba/archive/refs/tags/2024.09.25.tar.gz
+	source = mamba-2024.09.25-2024.09.30.tar.gz::https://github.com/mamba-org/mamba/archive/refs/tags/2024.09.25.tar.gz
 	sha512sums = 6b3e64255f8aa63723dd08f578f79195b46249a02002b6d0d77713fd181f0557e3b6044075a823e639b0240b07b4e17dd0c9c17790c9152a68992e3ca9a599fa
 
 pkgname = python-libmamba

--- a/pkgs/python-libmamba/PKGBUILD
+++ b/pkgs/python-libmamba/PKGBUILD
@@ -3,10 +3,10 @@
 # Contributor: Ke Liu <specter119@gmail.com>
 
 pkgname=python-libmamba
-pkgver=2.0.0
+pkgver=2024.09.30
 _srcver=2024.09.25
 _name=mamba-$_srcver
-pkgrel=2
+pkgrel=1
 pkgdesc="The fast cross-platform package manager"
 arch=('x86_64')
 url="https://github.com/mamba-org/mamba"


### PR DESCRIPTION
github.com update: mamba (2.0.0 -> 2024.09.30)