### PR TITLE
Update package scanpy from 1.10.2 to 1.10.3

### DIFF
--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scanpy
 	pkgdesc = Single-Cell Analysis in Python
-	pkgver = 1.10.2
+	pkgver = 1.10.3
 	pkgrel = 1
 	url = https://github.com/theislab/scanpy
 	arch = any
@@ -46,7 +46,7 @@ pkgbase = scanpy
 	optdepends = python-dask: Dask parallelization
 	provides = scanpy
 	provides = python-scanpy
-	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.10.2.tar.gz
-	sha256sums = 5d1649e73ac35e3ad02b455d8a16fdb16d4c8dc27330e696f4cd4e27f2d879be
+	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.10.3.tar.gz
+	sha256sums = 0a644d8fa173ac1c62aed4255de7031bf7501c7ad4441cf6ce99cd638b32f880
 
 pkgname = scanpy

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 
 pkgname=scanpy
-pkgver=1.10.2
+pkgver=1.10.3
 pkgrel=1
 pkgdesc='Single-Cell Analysis in Python'
 arch=(any)
@@ -48,7 +48,7 @@ optdepends=(
 )
 makedepends=(python-hatch python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha256sums=('5d1649e73ac35e3ad02b455d8a16fdb16d4c8dc27330e696f4cd4e27f2d879be')
+sha256sums=('0a644d8fa173ac1c62aed4255de7031bf7501c7ad4441cf6ce99cd638b32f880')
 
 build() {
 	cd "$pkgname-$pkgver"


### PR DESCRIPTION
PyPI update: scanpy (1.10.2 -> 1.10.3)
~ {'numpy<2,>=1.23 -> numpy>=1.23'}