### PR TITLE
Update package scanpy-scripts from 1.1.6 to 1.9.301

### DIFF
--- a/pkgs/scanpy-scripts/.SRCINFO
+++ b/pkgs/scanpy-scripts/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = scanpy-scripts
 	pkgdesc = Scripts for using scanpy from the command line
-	pkgver = 1.1.6
-	pkgrel = 2
+	pkgver = 1.9.301
+	pkgrel = 1
 	url = https://github.com/ebi-gene-expression-group/scanpy-scripts
 	arch = any
 	license = MIT
@@ -11,7 +11,7 @@ pkgbase = scanpy-scripts
 	makedepends = python-wheel
 	depends = scanpy
 	depends = python-click
-	source = https://files.pythonhosted.org/packages/source/s/scanpy-scripts/scanpy-scripts-1.1.6.tar.gz
-	sha256sums = 1701e35f93f5370ab451760b3892caf01b46d2898c3dd149e1dcba602e45eea1
+	source = https://files.pythonhosted.org/packages/source/s/scanpy-scripts/scanpy-scripts-1.9.301.tar.gz
+	sha256sums = c681d9cf5670d8b771b7327684f19d52f9661ee31e685241af4d960220a5d63b
 
 pkgname = scanpy-scripts

--- a/pkgs/scanpy-scripts/PKGBUILD
+++ b/pkgs/scanpy-scripts/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 
 pkgname=scanpy-scripts
-pkgver=1.1.6
-pkgrel=2
+pkgver=1.9.301
+pkgrel=1
 pkgdesc='Scripts for using scanpy from the command line'
 arch=(any)
 url='https://github.com/ebi-gene-expression-group/scanpy-scripts'
@@ -10,7 +10,7 @@ license=(MIT)
 depends=(scanpy python-click)
 makedepends=(python-setuptools python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha256sums=('1701e35f93f5370ab451760b3892caf01b46d2898c3dd149e1dcba602e45eea1')
+sha256sums=('c681d9cf5670d8b771b7327684f19d52f9661ee31e685241af4d960220a5d63b')
 
 build() {
 	cd "$pkgname-$pkgver"


### PR DESCRIPTION
PyPI update: scanpy-scripts (1.1.6 -> 1.9.301)
- {'h5py', 'umap-learn', 'pandas', 'matplotlib', 'anndata', 'packaging', 'scikit-misc'}
+ {'scikit-learn', 'igraph'}
~ {'bbknn>=1.5.0 -> bbknn<1.6.0,>=1.5.0', 'scipy -> scipy<1.9.0', 'scanpy==1.8.1 -> scanpy==1.9.3'}