### PR TITLE
Update package python-zarr from 2.18.3 to 2.18.4

### DIFF
--- a/pkgs/python-zarr/.SRCINFO
+++ b/pkgs/python-zarr/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-zarr
 	pkgdesc = An implementation of chunked, compressed, N-dimensional arrays for Python
-	pkgver = 2.18.3
+	pkgver = 2.18.4
 	pkgrel = 1
 	url = https://github.com/zarr-developers/zarr-python
 	arch = any
@@ -14,7 +14,7 @@ pkgbase = python-zarr
 	depends = python-numpy
 	depends = python-fasteners
 	depends = python-numcodecs
-	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-2.18.3.tar.gz
-	sha256sums = 2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce
+	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-2.18.4.tar.gz
+	sha256sums = 37790ededd0683ae1abe6ff90aa16c22543b3436810060f53d72c15e910c24bb
 
 pkgname = python-zarr

--- a/pkgs/python-zarr/PKGBUILD
+++ b/pkgs/python-zarr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 _name=zarr
 pkgname=python-zarr
-pkgver=2.18.3
+pkgver=2.18.4
 pkgrel=1
 pkgdesc='An implementation of chunked, compressed, N-dimensional arrays for Python'
 arch=(any)
@@ -10,7 +10,7 @@ license=(MIT)
 depends=(python-asciitree python-numpy python-fasteners python-numcodecs)
 makedepends=(python-setuptools python-setuptools-scm python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('2580d8cb6dd84621771a10d31c4d777dca8a27706a1a89b29f42d2d37e2df5ce')
+sha256sums=('37790ededd0683ae1abe6ff90aa16c22543b3436810060f53d72c15e910c24bb')
 
 build() {
 	cd "$_name-$pkgver"


### PR DESCRIPTION
PyPI update: zarr (2.18.3 -> 2.18.4)
~ {'numcodecs>=0.10.0 -> numcodecs!=0.14.0,!=0.14.1,>=0.10.0'}