### PR TITLE
Update package python-wheel-filename from 1.4.1 to 1.4.2

### DIFF
--- a/pkgs/python-wheel-filename/.SRCINFO
+++ b/pkgs/python-wheel-filename/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = python-wheel-filename
 	pkgdesc = Parse wheel filenames
-	pkgver = 1.4.1
-	pkgrel = 2
+	pkgver = 1.4.2
+	pkgrel = 1
 	url = https://github.com/jwodder/wheel-filename
 	arch = any
 	license = MIT
@@ -10,7 +10,7 @@ pkgbase = python-wheel-filename
 	makedepends = python-installer
 	makedepends = python-wheel
 	depends = python
-	source = https://files.pythonhosted.org/packages/source/w/wheel-filename/wheel-filename-1.4.1.tar.gz
-	sha256sums = e2e1eb0780910a0148358252aad6394cc674250686c56c39aa379493438370b3
+	source = https://files.pythonhosted.org/packages/source/w/wheel-filename/wheel_filename-1.4.2.tar.gz
+	sha256sums = 87891c465dcbb40b40394a906f01a93214bdd51aa5d25e3a9a59cae62bc298fd
 
 pkgname = python-wheel-filename

--- a/pkgs/python-wheel-filename/PKGBUILD
+++ b/pkgs/python-wheel-filename/PKGBUILD
@@ -2,8 +2,8 @@
 
 _name=wheel-filename
 pkgname=python-$_name
-pkgver=1.4.1
-pkgrel=2
+pkgver=1.4.2
+pkgrel=1
 pkgdesc='Parse wheel filenames'
 arch=(any)
 url="https://github.com/jwodder/$_name"


### PR DESCRIPTION
PyPI update: wheel-filename (1.4.1 -> 1.4.2)