### PR TITLE
Update package python-numcodecs from 0.14.1 to 0.15.0

### DIFF
--- a/pkgs/python-numcodecs/.SRCINFO
+++ b/pkgs/python-numcodecs/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-numcodecs
 	pkgdesc = A Python package providing buffer compression and transformation codecs for use in data storage and communication applications
-	pkgver = 0.14.1
+	pkgver = 0.15.0
 	pkgrel = 1
 	url = https://github.com/zarr-developers/numcodecs
 	arch = x86_64
@@ -16,7 +16,7 @@ pkgbase = python-numcodecs
 	depends = python-msgpack
 	optdepends = python-zfpy
 	optdepends = python-pcodec
-	source = https://files.pythonhosted.org/packages/source/n/numcodecs/numcodecs-0.14.1.tar.gz
-	sha256sums = 00a364924fd2d600bcce6e2ced96b47c40eb5f9d84bf4b0207aa208d9ce6cd1c
+	source = https://files.pythonhosted.org/packages/source/n/numcodecs/numcodecs-0.15.0.tar.gz
+	sha256sums = 52fb0c20d99845ef600eb3f8c8ad3e22fe2cb4f2a53394d331210af7cc3375ca
 
 pkgname = python-numcodecs

--- a/pkgs/python-numcodecs/PKGBUILD
+++ b/pkgs/python-numcodecs/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 _name=numcodecs
 pkgname=python-numcodecs
-pkgver=0.14.1
+pkgver=0.15.0
 pkgrel=1
 pkgdesc='A Python package providing buffer compression and transformation codecs for use in data storage and communication applications'
 arch=(x86_64)
@@ -11,7 +11,7 @@ depends=(python-numpy python-msgpack)
 makedepends=(cython python-py-cpuinfo python-setuptools python-setuptools-scm python-build python-installer python-wheel)
 optdepends=(python-zfpy python-pcodec)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('00a364924fd2d600bcce6e2ced96b47c40eb5f9d84bf4b0207aa208d9ce6cd1c')
+sha256sums=('52fb0c20d99845ef600eb3f8c8ad3e22fe2cb4f2a53394d331210af7cc3375ca')
 
 build() {
 	cd "$_name-$pkgver"


### PR DESCRIPTION
PyPI update: numcodecs (0.14.1 -> 0.15.0)
+ {'deprecated'}