### PR TITLE
Update package scanpy from 1.10.4 to 1.11.0

### DIFF
--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scanpy
 	pkgdesc = Single-Cell Analysis in Python
-	pkgver = 1.10.4
+	pkgver = 1.11.0
 	pkgrel = 1
 	url = https://github.com/theislab/scanpy
 	arch = any
@@ -46,7 +46,7 @@ pkgbase = scanpy
 	optdepends = python-dask: Dask parallelization
 	provides = scanpy
 	provides = python-scanpy
-	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.10.4.tar.gz
-	sha256sums = 2682fbbe2e4106c349472feebef08e174062fb666db4c94123758c6a7a470396
+	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.11.0.tar.gz
+	sha256sums = f41bdbd6ee3836de8a4eb5c0828dbdcb0fb014930eacbb0049b37bcb84a74d54
 
 pkgname = scanpy

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 
 pkgname=scanpy
-pkgver=1.10.4
+pkgver=1.11.0
 pkgrel=1
 pkgdesc='Single-Cell Analysis in Python'
 arch=(any)
@@ -48,7 +48,7 @@ optdepends=(
 )
 makedepends=(python-hatch python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha256sums=('2682fbbe2e4106c349472feebef08e174062fb666db4c94123758c6a7a470396')
+sha256sums=('f41bdbd6ee3836de8a4eb5c0828dbdcb0fb014930eacbb0049b37bcb84a74d54')
 
 build() {
 	cd "$pkgname-$pkgver"


### PR DESCRIPTION
PyPI update: scanpy (1.10.4 -> 1.11.0)
- {'session-info'}
+ {'session-info2'}
~ {'numpy>=1.23 -> numpy>=1.24', 'h5py>=3.6 -> h5py>=3.7', 'scikit-learn>=1.1 -> scikit-learn<1.6.0,>=1.1', 'numba>=0.56 -> numba>=0.57'}