### PR TITLE
Update package python-zarr from 3.0.0 to 3.0.4

### DIFF
--- a/pkgs/python-zarr/.SRCINFO
+++ b/pkgs/python-zarr/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-zarr
 	pkgdesc = An implementation of chunked, compressed, N-dimensional arrays for Python
-	pkgver = 3.0.0
+	pkgver = 3.0.4
 	pkgrel = 1
 	url = https://github.com/zarr-developers/zarr-python
 	arch = any
@@ -15,7 +15,7 @@ pkgbase = python-zarr
 	depends = python-crc32c
 	depends = python-typing_extensions
 	depends = python-donfig
-	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-3.0.0.tar.gz
-	sha256sums = d491480e35d344125671d7300ddcd5fd86d5ec060480d79bd450d203a98b9cda
+	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-3.0.4.tar.gz
+	sha256sums = 6ebe6d65d1f6eafb5ebb8e434fc6e577b0d0c033afebf1bb5cd1efd46794d398
 
 pkgname = python-zarr

--- a/pkgs/python-zarr/PKGBUILD
+++ b/pkgs/python-zarr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 _name=zarr
 pkgname=python-zarr
-pkgver=3.0.0
+pkgver=3.0.4
 pkgrel=1
 pkgdesc='An implementation of chunked, compressed, N-dimensional arrays for Python'
 arch=(any)
@@ -10,7 +10,7 @@ license=(MIT)
 depends=(python-packaging python-numpy python-numcodecs python-crc32c python-typing_extensions python-donfig)
 makedepends=(python-hatchling python-hatch-vcs python-build python-installer)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('d491480e35d344125671d7300ddcd5fd86d5ec060480d79bd450d203a98b9cda')
+sha256sums=('6ebe6d65d1f6eafb5ebb8e434fc6e577b0d0c033afebf1bb5cd1efd46794d398')
 
 build() {
 	cd "$_name-$pkgver"


### PR DESCRIPTION
PyPI update: zarr (3.0.0 -> 3.0.4)
\- {'pytest', 'numcodecs', 'crc32c', 'fasteners', 'zstandard', 'asciitree', 'fsspec'}
\+ {'packaging', 'numcodecs[crc32c]'}
~ {'donfig -> donfig>=0.8', 'numpy>=1.24 -> numpy>=1.25', 'typing-extensions -> typing-extensions>=4.9'}