### PR TITLE
Update package python-array-api-compat from 1.11 to 1.11.2

### DIFF
--- a/pkgs/python-array-api-compat/.SRCINFO
+++ b/pkgs/python-array-api-compat/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-array-api-compat
 	pkgdesc = A wrapper around NumPy and other array libraries to make them compatible with the Array API standard.
-	pkgver = 1.11
+	pkgver = 1.11.2
 	pkgrel = 1
 	url = https://data-apis.org/array-api-compat/
 	arch = any
@@ -16,7 +16,7 @@ pkgbase = python-array-api-compat
 	optdepends = python-pytorch
 	optdepends = python-dask
 	optdepends = python-sparse
-	source = https://files.pythonhosted.org/packages/source/a/array-api-compat/array_api_compat-1.11.tar.gz
-	sha256sums = 2ebd4a138cb710d0703e0913fadf5545957dc9e6cc56a0ad1abdded002623c04
+	source = https://files.pythonhosted.org/packages/source/a/array-api-compat/array_api_compat-1.11.2.tar.gz
+	sha256sums = a3b7f7b6af18f4c42e79423b1b2479798998b6a74355069d77a01a5282755b5d
 
 pkgname = python-array-api-compat

--- a/pkgs/python-array-api-compat/PKGBUILD
+++ b/pkgs/python-array-api-compat/PKGBUILD
@@ -2,7 +2,7 @@
 
 _name=array-api-compat
 pkgname=python-$_name
-pkgver=1.11
+pkgver=1.11.2
 pkgrel=1
 pkgdesc='A wrapper around NumPy and other array libraries to make them compatible with the Array API standard.'
 arch=(any)
@@ -12,7 +12,7 @@ depends=(python)
 optdepends=(python-numpy python-cupy python-jax python-pytorch python-dask python-sparse)
 makedepends=(python-setuptools python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/${_name//-/_}-$pkgver.tar.gz")
-sha256sums=('2ebd4a138cb710d0703e0913fadf5545957dc9e6cc56a0ad1abdded002623c04')
+sha256sums=('a3b7f7b6af18f4c42e79423b1b2479798998b6a74355069d77a01a5282755b5d')
 
 build() {
 	cd "${_name//-/_}-$pkgver"


### PR DESCRIPTION
PyPI update: array-api-compat (1.11 -> 1.11.2)