### PR TITLE
Update package python-scanpydoc from 0.15.3 to 0.15.4

### DIFF
--- a/pkgs/python-scanpydoc/.SRCINFO
+++ b/pkgs/python-scanpydoc/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-scanpydoc
 	pkgdesc = A series of Sphinx extensions to get easy to maintain, numpydoc style documentation.
-	pkgver = 0.15.3
+	pkgver = 0.15.4
 	pkgrel = 1
 	url = https://github.com/theislab/scanpydoc
 	arch = any
@@ -11,7 +11,7 @@ pkgbase = python-scanpydoc
 	makedepends = python-installer
 	makedepends = python-wheel
 	depends = python-sphinx
-	source = https://files.pythonhosted.org/packages/source/s/scanpydoc/scanpydoc-0.15.3.tar.gz
-	sha256sums = c4b736627d4ed1cb4c53e7b434d1001bfdb651aa355832dec3d8ba2f56393476
+	source = https://files.pythonhosted.org/packages/source/s/scanpydoc/scanpydoc-0.15.4.tar.gz
+	sha256sums = 6c5b4296d699c132de0e73e78bda03a4901b8b8a70ca013bee4e02fcaee2aef3
 
 pkgname = python-scanpydoc

--- a/pkgs/python-scanpydoc/PKGBUILD
+++ b/pkgs/python-scanpydoc/PKGBUILD
@@ -2,7 +2,7 @@
 
 _name=scanpydoc
 pkgname=python-$_name
-pkgver=0.15.3
+pkgver=0.15.4
 pkgrel=1
 pkgdesc='A series of Sphinx extensions to get easy to maintain, numpydoc style documentation.'
 arch=(any)
@@ -11,7 +11,7 @@ license=(GPL3)
 depends=(python-sphinx)
 makedepends=(python-hatchling python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('c4b736627d4ed1cb4c53e7b434d1001bfdb651aa355832dec3d8ba2f56393476')
+sha256sums=('6c5b4296d699c132de0e73e78bda03a4901b8b8a70ca013bee4e02fcaee2aef3')
 
 build() {
 	cd "$_name-$pkgver"


### PR DESCRIPTION
PyPI update: scanpydoc (0.15.3 -> 0.15.4)