### PR TITLE
Update package scanpy from 1.10.4 to 1.11.3

### DIFF
--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scanpy
 	pkgdesc = Single-Cell Analysis in Python
-	pkgver = 1.10.4
+	pkgver = 1.11.3
 	pkgrel = 1
 	url = https://github.com/theislab/scanpy
 	arch = any
@@ -46,7 +46,7 @@ pkgbase = scanpy
 	optdepends = python-dask: Dask parallelization
 	provides = scanpy
 	provides = python-scanpy
-	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.10.4.tar.gz
-	sha256sums = 2682fbbe2e4106c349472feebef08e174062fb666db4c94123758c6a7a470396
+	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.11.3.tar.gz
+	sha256sums = ead448f112bb07351897531c24e05627f4b3e0bee0c02f50adf378f4e08e338b
 
 pkgname = scanpy

--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -11,25 +11,25 @@ pkgbase = scanpy
 	makedepends = python-installer
 	makedepends = python-wheel
 	depends = python-anndata>=0.8
-	depends = python-numpy>=1.23
-	depends = python-matplotlib>=3.6
-	depends = python-pandas>=1.5
-	depends = python-scipy>=1.8
-	depends = python-seaborn>=0.13
-	depends = python-h5py>=3.6
+	depends = python-numpy>=1.24.1
+	depends = python-matplotlib>=3.7.5
+	depends = python-pandas>=1.5.3
+	depends = python-scipy>=1.8.1
+	depends = python-seaborn>=0.13.2
+	depends = python-h5py>=3.7
 	depends = python-tqdm
-	depends = python-scikit-learn>=1.1
-	depends = python-statsmodels>=0.13
+	depends = python-scikit-learn>=1.1.3
+	depends = python-statsmodels>=0.14.4
 	depends = python-patsy>=1.0.1
-	depends = python-networkx>=2.7
+	depends = python-networkx>=2.7.1
 	depends = python-natsort
 	depends = python-joblib
-	depends = python-numba>=0.56
-	depends = python-umap-learn>=0.5.1
+	depends = python-numba>=0.57.1
+	depends = python-umap-learn>=0.5.6
 	depends = python-pynndescent>=0.5.13
 	depends = python-packaging>=21.3
-	depends = python-session-info
-	depends = python-legacy-api-wrap>=1.4
+	depends = python-session-info2
+	depends = python-legacy-api-wrap>=1.4.1
 	optdepends = python-igraph: PAGA support (also transitively needed for Louvain/Leiden)
 	optdepends = python-louvain-igraph: Louvain clustering
 	optdepends = python-leidenalg: leiden community detection

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -10,25 +10,25 @@ url='https://github.com/theislab/scanpy'
 license=(BSD)
 depends=(
 	'python-anndata>=0.8'
-	'python-numpy>=1.23'
-	'python-matplotlib>=3.6'
-	'python-pandas>=1.5'
-	'python-scipy>=1.8'
-	'python-seaborn>=0.13'
-	'python-h5py>=3.6'
+	'python-numpy>=1.24.1'
+	'python-matplotlib>=3.7.5'
+	'python-pandas>=1.5.3'
+	'python-scipy>=1.8.1'
+	'python-seaborn>=0.13.2'
+	'python-h5py>=3.7'
 	python-tqdm
-	'python-scikit-learn>=1.1'
-	'python-statsmodels>=0.13'
+	'python-scikit-learn>=1.1.3'
+	'python-statsmodels>=0.14.4'
 	'python-patsy>=1.0.1'
-	'python-networkx>=2.7'
+	'python-networkx>=2.7.1'
 	python-natsort
 	python-joblib
-	'python-numba>=0.56'
-	'python-umap-learn>=0.5.1'
+	'python-numba>=0.57.1'
+	'python-umap-learn>=0.5.6'
 	'python-pynndescent>=0.5.13'
 	'python-packaging>=21.3'
-	python-session-info
-	'python-legacy-api-wrap>=1.4'
+	python-session-info2
+	'python-legacy-api-wrap>=1.4.1'
 )
 optdepends=(
 	'python-igraph: PAGA support (also transitively needed for Louvain/Leiden)'

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 
 pkgname=scanpy
-pkgver=1.10.4
+pkgver=1.11.3
 pkgrel=1
 pkgdesc='Single-Cell Analysis in Python'
 arch=(any)
@@ -48,7 +48,7 @@ optdepends=(
 )
 makedepends=(python-hatch python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha256sums=('2682fbbe2e4106c349472feebef08e174062fb666db4c94123758c6a7a470396')
+sha256sums=('ead448f112bb07351897531c24e05627f4b3e0bee0c02f50adf378f4e08e338b')
 
 build() {
 	cd "$pkgname-$pkgver"


### PR DESCRIPTION
PyPI update: scanpy (1.10.4 -> 1.11.3)
\- {'session-info'}
\+ {'session-info2'}
\~ {'pynndescent>=0.5 -> pynndescent>=0.5.13', 'matplotlib>=3.6 -> matplotlib>=3.7.5', 'statsmodels>=0.13 -> statsmodels>=0.14.4', 'scipy>=1.8 -> scipy<1.16.0,>=1.8.1', 'h5py>=3.6 -> h5py>=3.7.0', 'scikit-learn>=1.1 -> scikit-learn>=1.1.3', 'numpy>=1.23 -> numpy>=1.24.1', 'pandas>=1.5 -> pandas>=1.5.3', 'networkx>=2.7 -> networkx>=2.7.1', 'umap-learn!=0.5.0,>=0.5 -> umap-learn>=0.5.6', 'numba>=0.56 -> numba>=0.57.1', 'seaborn>=0.13 -> seaborn>=0.13.2', 'legacy-api-wrap>=1.4 -> legacy-api-wrap>=1.4.1'}