### PR TITLE
Update package scanpy from 1.11.3 to 1.11.4

### DIFF
--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -19,7 +19,7 @@ pkgbase = scanpy
 	depends = python-h5py>=3.7
 	depends = python-tqdm
 	depends = python-scikit-learn>=1.1.3
-	depends = python-statsmodels>=0.14.4
+	depends = python-statsmodels>=0.14.5
 	depends = python-patsy>=1.0.1
 	depends = python-networkx>=2.7.1
 	depends = python-natsort

--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scanpy
 	pkgdesc = Single-Cell Analysis in Python
-	pkgver = 1.11.3
+	pkgver = 1.11.4
 	pkgrel = 1
 	url = https://github.com/theislab/scanpy
 	arch = any
@@ -46,7 +46,7 @@ pkgbase = scanpy
 	optdepends = python-dask: Dask parallelization
 	provides = scanpy
 	provides = python-scanpy
-	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.11.3.tar.gz
-	sha256sums = ead448f112bb07351897531c24e05627f4b3e0bee0c02f50adf378f4e08e338b
+	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.11.4.tar.gz
+	sha256sums = 333189ecac9c7009bf55d416ee2e272e1c490d54c719478f7b4dd1fc294d2f95
 
 pkgname = scanpy

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 
 pkgname=scanpy
-pkgver=1.11.3
+pkgver=1.11.4
 pkgrel=1
 pkgdesc='Single-Cell Analysis in Python'
 arch=(any)
@@ -48,7 +48,7 @@ optdepends=(
 )
 makedepends=(python-hatch python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha256sums=('ead448f112bb07351897531c24e05627f4b3e0bee0c02f50adf378f4e08e338b')
+sha256sums=('333189ecac9c7009bf55d416ee2e272e1c490d54c719478f7b4dd1fc294d2f95')
 
 build() {
 	cd "$pkgname-$pkgver"

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -18,7 +18,7 @@ depends=(
 	'python-h5py>=3.7'
 	python-tqdm
 	'python-scikit-learn>=1.1.3'
-	'python-statsmodels>=0.14.4'
+	'python-statsmodels>=0.14.5'
 	'python-patsy>=1.0.1'
 	'python-networkx>=2.7.1'
 	python-natsort


### PR DESCRIPTION
PyPI update: scanpy (1.11.3 -> 1.11.4)
\~ {'scipy<1.16.0,>=1.8.1 -> scipy>=1.8.1', 'statsmodels>=0.14.4 -> statsmodels>=0.14.5'}