### PR TITLE
Update package scanpy from 1.11.5 to 1.12.3

### DIFF
--- a/pkgs/scanpy/.SRCINFO
+++ b/pkgs/scanpy/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = scanpy
 	pkgdesc = Single-Cell Analysis in Python
-	pkgver = 1.11.5
+	pkgver = 1.12
 	pkgrel = 1
 	url = https://github.com/theislab/scanpy
 	arch = any
@@ -46,7 +46,7 @@ pkgbase = scanpy
 	optdepends = python-dask: Dask parallelization
 	provides = scanpy
 	provides = python-scanpy
-	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.11.5.tar.gz
-	sha256sums = b2ef5476dfb1144b7dd0fae90b0198699c7988e6b27f083904150642c7ba6b89
+	source = https://files.pythonhosted.org/packages/source/s/scanpy/scanpy-1.12.tar.gz
+	sha256sums = 8139840bb948ce0aa0798c9b8b88c1df4f06c27641a792f0995d39cd4dcf858a
 
 pkgname = scanpy

--- a/pkgs/scanpy/PKGBUILD
+++ b/pkgs/scanpy/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 
 pkgname=scanpy
-pkgver=1.11.5
+pkgver=1.12
 pkgrel=1
 pkgdesc='Single-Cell Analysis in Python'
 arch=(any)
@@ -48,7 +48,7 @@ optdepends=(
 )
 makedepends=(python-hatch python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${pkgname::1}/$pkgname/$pkgname-$pkgver.tar.gz")
-sha256sums=('b2ef5476dfb1144b7dd0fae90b0198699c7988e6b27f083904150642c7ba6b89')
+sha256sums=('8139840bb948ce0aa0798c9b8b88c1df4f06c27641a792f0995d39cd4dcf858a')
 
 build() {
 	cd "$pkgname-$pkgver"


### PR DESCRIPTION
PyPI update: scanpy (1.11.5 -> 1.12.3)
\+ {'scverse-misc', 'certifi', 'fast-array-utils[accel,sparse]'}
\~ {'umap-learn>=0.5.6 -> umap-learn>=0.5.12', 'packaging>=21.3 -> packaging>=25', 'pandas>=1.5.3 -> pandas>=2.3', 'h5py>=3.7.0 -> h5py>=3.11', 'patsy!=1.0.0 -> patsy', 'numba!=0.62.0rc1,>=0.57.1 -> numba>=0.60', 'numpy>=1.24.1 -> numpy>=2', 'scipy>=1.8.1 -> scipy>=1.13', 'anndata>=0.8 -> anndata>=0.10.8', 'legacy-api-wrap>=1.4.1 -> legacy-api-wrap>=1.5', 'networkx>=2.7.1 -> networkx>=2.8.8', 'matplotlib>=3.7.5 -> matplotlib>=3.10', 'scikit-learn>=1.1.3 -> scikit-learn>=1.6'}