### PR TITLE
Update package python-scanpydoc from 0.17.1 to 0.17.3

### DIFF
--- a/pkgs/python-scanpydoc/.SRCINFO
+++ b/pkgs/python-scanpydoc/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-scanpydoc
 	pkgdesc = A series of Sphinx extensions to get easy to maintain, numpydoc style documentation.
-	pkgver = 0.17.1
+	pkgver = 0.17.3
 	pkgrel = 1
 	url = https://github.com/theislab/scanpydoc
 	arch = any
@@ -11,7 +11,7 @@ pkgbase = python-scanpydoc
 	makedepends = python-installer
 	makedepends = python-wheel
 	depends = python-sphinx
-	source = https://files.pythonhosted.org/packages/source/s/scanpydoc/scanpydoc-0.17.1.tar.gz
-	sha256sums = 966e249a2d48a8f1299e99d34179359a0c908120dc7f4ecc7743dc490088d445
+	source = https://files.pythonhosted.org/packages/source/s/scanpydoc/scanpydoc-0.17.3.tar.gz
+	sha256sums = a0b310549ddd798670c143aa17cd442279e822911fe9ccd24dca5f525789ceec
 
 pkgname = python-scanpydoc

--- a/pkgs/python-scanpydoc/PKGBUILD
+++ b/pkgs/python-scanpydoc/PKGBUILD
@@ -2,7 +2,7 @@
 
 _name=scanpydoc
 pkgname=python-$_name
-pkgver=0.17.1
+pkgver=0.17.3
 pkgrel=1
 pkgdesc='A series of Sphinx extensions to get easy to maintain, numpydoc style documentation.'
 arch=(any)
@@ -11,7 +11,7 @@ license=(GPL3)
 depends=(python-sphinx)
 makedepends=(python-hatchling python-hatch-vcs python-build python-installer python-wheel)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('966e249a2d48a8f1299e99d34179359a0c908120dc7f4ecc7743dc490088d445')
+sha256sums=('a0b310549ddd798670c143aa17cd442279e822911fe9ccd24dca5f525789ceec')
 
 build() {
 	cd "$_name-$pkgver"


### PR DESCRIPTION
PyPI update: scanpydoc (0.17.1 -> 0.17.3)
\~ {'sphinx>=7.0 -> sphinx>=8.2'}