### PR TITLE
Update package python-zarr from 3.1.5 to 3.2.1

### DIFF
--- a/pkgs/python-zarr/.SRCINFO
+++ b/pkgs/python-zarr/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = python-zarr
 	pkgdesc = An implementation of chunked, compressed, N-dimensional arrays for Python
-	pkgver = 3.1.5
+	pkgver = 3.2.1
 	pkgrel = 1
 	url = https://github.com/zarr-developers/zarr-python
 	arch = any
@@ -15,7 +15,7 @@ pkgbase = python-zarr
 	depends = python-google-crc32c
 	depends = python-typing_extensions
 	depends = python-donfig
-	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-3.1.5.tar.gz
-	sha256sums = fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b
+	source = https://files.pythonhosted.org/packages/source/z/zarr/zarr-3.2.1.tar.gz
+	sha256sums = 71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035
 
 pkgname = python-zarr

--- a/pkgs/python-zarr/PKGBUILD
+++ b/pkgs/python-zarr/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Philipp A. <flying-sheep@web.de>
 _name=zarr
 pkgname=python-zarr
-pkgver=3.1.5
+pkgver=3.2.1
 pkgrel=1
 pkgdesc='An implementation of chunked, compressed, N-dimensional arrays for Python'
 arch=(any)
@@ -10,7 +10,7 @@ license=(MIT)
 depends=(python-packaging python-numpy python-numcodecs python-google-crc32c python-typing_extensions python-donfig)
 makedepends=(python-hatchling python-hatch-vcs python-build python-installer)
 source=("https://files.pythonhosted.org/packages/source/${_name::1}/$_name/$_name-$pkgver.tar.gz")
-sha256sums=('fbe0c79675a40c996de7ca08e80a1c0a20537bd4a9f43418b6d101395c0bba2b')
+sha256sums=('71565b738a0e7e8ed226f0516eba8c6bb53440ad7669a8c48ebb3534a161d035')
 
 build() {
 	cd "$_name-$pkgver"


### PR DESCRIPTION
PyPI update: zarr (3.1.5 -> 3.2.1)
\~ {'numpy>=1.26 -> numpy>=2', 'typing-extensions>=4.9 -> typing-extensions>=4.13'}